### PR TITLE
Correct typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ func main() {
 	})
 	mw := ratelimit.RateLimiter(store, &ratelimit.Options{
 		ErrorHandler: errorHandler,
-		KeyFunc: keyfunc,
+		KeyFunc: keyFunc,
     })
 	server.GET("/", mw, func(c *gin.Context) {
 		c.String(200, "Hello World")
@@ -88,7 +88,7 @@ func main() {
 	})
 	mw := ratelimit.RateLimiter(store, &ratelimit.Options{
 		ErrorHandler: errorHandler,
-		KeyFunc: keyfunc,
+		KeyFunc: keyFunc,
 	})
 	server.GET("/", mw, func(c *gin.Context) {
 		c.String(200, "Hello World")

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ func main() {
 		Limit: 5,
 	})
 	mw := ratelimit.RateLimiter(store, &ratelimit.Options{
-		ErrorHanlder: errorHandler,
+		ErrorHandler: errorHandler,
 		KeyFunc: keyfunc,
     })
 	server.GET("/", mw, func(c *gin.Context) {
@@ -87,7 +87,7 @@ func main() {
 		Limit: 5,
 	})
 	mw := ratelimit.RateLimiter(store, &ratelimit.Options{
-		ErrorHanlder: errorHandler,
+		ErrorHandler: errorHandler,
 		KeyFunc: keyfunc,
 	})
 	server.GET("/", mw, func(c *gin.Context) {


### PR DESCRIPTION
Fixed typo in readme code snippets that causes an error if copy-pasted.