### PR TITLE
feat: add Retry-After header to default ErrorHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,54 @@ func main() {
 <br>
 
 
+Response Headers
+
+By default, the package emits the de-facto `X-Rate-Limit-*` headers on every
+response (set by `BeforeResponse`) and on rate-limited responses (set by the
+default `ErrorHandler`):
+
+| Header | Set on | Description |
+|--------|--------|-------------|
+| `X-Rate-Limit-Limit` | every response | Total request limit per window |
+| `X-Rate-Limit-Remaining` | every response | Remaining requests in window |
+| `X-Rate-Limit-Reset` | every response | Unix timestamp when window resets |
+
+If you prefer the standard `Retry-After` header (RFC 9110 §10.2.3) instead,
+opt in by passing both `RFCErrorHandler` and `RFCBeforeResponse`. The two
+go together — using only one would mix conventions on the same response.
+
+```go
+mw := ratelimit.RateLimiter(store, &ratelimit.Options{
+    ErrorHandler:   ratelimit.RFCErrorHandler,
+    BeforeResponse: ratelimit.RFCBeforeResponse,
+})
+```
+
+This emits only `Retry-After: <seconds>` on 429 responses and no rate-limit
+headers on successful responses.
+
+If you want a custom 429 body (for example, JSON to match your API
+conventions) while still using the standard `Retry-After` header, write
+your own `ErrorHandler` and use the public `RetryAfterSeconds` helper:
+
+```go
+func errorHandler(c *gin.Context, info ratelimit.Info) {
+    c.Header("Retry-After", strconv.FormatInt(ratelimit.RetryAfterSeconds(info.ResetTime), 10))
+    c.JSON(429, gin.H{"error": "too many requests"})
+}
+
+mw := ratelimit.RateLimiter(store, &ratelimit.Options{
+    ErrorHandler:   errorHandler,
+    BeforeResponse: ratelimit.RFCBeforeResponse, // suppress X-Rate-Limit-* on success too
+})
+```
+
+`RetryAfterSeconds` returns `ceil(time.Until(resetTime).Seconds())` floored
+at 1, so the client never retries before the window has elapsed.
+
+<br>
+
+
 Custom Store Example
 
 ```go

--- a/gin_rate_limit.go
+++ b/gin_rate_limit.go
@@ -2,8 +2,10 @@ package ratelimit
 
 import (
 	"fmt"
-	"github.com/gin-gonic/gin"
+	"math"
 	"time"
+
+	"github.com/gin-gonic/gin"
 )
 
 type Info struct {
@@ -24,6 +26,38 @@ type Options struct {
 	// a function that lets you check the rate limiting info and modify the response
 	BeforeResponse func(c *gin.Context, info Info)
 }
+
+// RetryAfterSeconds returns the number of whole seconds until resetTime,
+// rounded up so the client never retries before the window has elapsed.
+// Always returns at least 1. Useful when building a custom ErrorHandler
+// that emits the standard Retry-After header (RFC 9110).
+func RetryAfterSeconds(resetTime time.Time) int64 {
+	s := int64(math.Ceil(time.Until(resetTime).Seconds()))
+	if s < 1 {
+		return 1
+	}
+	return s
+}
+
+// RFCErrorHandler is an alternative ErrorHandler that emits the RFC 9110
+// Retry-After header instead of the de-facto X-Rate-Limit-* headers used
+// by the default. Pair with RFCBeforeResponse to avoid mixing the two
+// header conventions on the same response.
+//
+//	ratelimit.RateLimiter(store, &ratelimit.Options{
+//	    ErrorHandler:   ratelimit.RFCErrorHandler,
+//	    BeforeResponse: ratelimit.RFCBeforeResponse,
+//	})
+func RFCErrorHandler(c *gin.Context, info Info) {
+	c.Header("Retry-After", fmt.Sprintf("%d", RetryAfterSeconds(info.ResetTime)))
+	c.String(429, "Too many requests")
+}
+
+// RFCBeforeResponse is a no-op BeforeResponse callback. Use it together
+// with RFCErrorHandler when you want only RFC 9110 Retry-After headers
+// on rate-limited responses, with no X-Rate-Limit-* headers on successful
+// responses.
+func RFCBeforeResponse(c *gin.Context, info Info) {}
 
 // RateLimiter is a function to get gin.HandlerFunc
 func RateLimiter(s Store, options *Options) gin.HandlerFunc {


### PR DESCRIPTION
## Summary

Adds opt-in support for the standard RFC 9110 `Retry-After` header on rate-limited responses, without changing the existing default behaviour. The default `ErrorHandler` continues to emit the de-facto `X-Rate-Limit-*` headers introduced in #5.

The previous version of this PR added `Retry-After` to the default handler, which mixed the two conventions on the same response. Reworked to be opt-in.

## What's added

- `RetryAfterSeconds(resetTime)` — public helper for users building custom handlers (`ceil(seconds until reset)`, floored at 1)
- `RFCErrorHandler` — alternative `ErrorHandler` that emits `Retry-After` instead of `X-Rate-Limit-*`
- `RFCBeforeResponse` — no-op `BeforeResponse` to pair with `RFCErrorHandler`, so successful responses don't get `X-Rate-Limit-*` headers either

## Usage

```go
ratelimit.RateLimiter(store, &ratelimit.Options{
    ErrorHandler:   ratelimit.RFCErrorHandler,
    BeforeResponse: ratelimit.RFCBeforeResponse,
})
```

Both pieces are needed to fully avoid mixing — `BeforeResponse` runs on every request including 429s, so the no-op variant prevents `X-Rate-Limit-*` from ending up alongside `Retry-After`.

## Backward compatibility

100% — no existing user is affected. The default handlers are untouched.

## References

- [RFC 9110 §10.2.3 — Retry-After](https://www.rfc-editor.org/rfc/rfc9110#field.retry-after)
- [MDN — 429 Too Many Requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429)